### PR TITLE
make a copy, don't grab the ref

### DIFF
--- a/demo/app.py
+++ b/demo/app.py
@@ -40,9 +40,9 @@ async def main():
     # Handle agent execution button click
     if run_button:
         agent, agent_config = await configure_agent(user_inputs)
-        agent_trace, execution_time = await run_agent(agent, agent_config)
+        agent_trace = await run_agent(agent, agent_config)
 
-        await display_output(agent_trace, execution_time)
+        await display_output(agent_trace)
 
         evaluation_result = await evaluate_agent(agent_config, agent_trace)
 

--- a/demo/components/inputs.py
+++ b/demo/components/inputs.py
@@ -8,6 +8,7 @@ from any_agent.evaluation import EvaluationCase
 from any_agent.evaluation.schemas import CheckpointCriteria
 import pandas as pd
 from constants import DEFAULT_EVALUATION_CASE, MODEL_OPTIONS
+import copy
 
 from pydantic import BaseModel, ConfigDict
 
@@ -98,7 +99,7 @@ def get_user_inputs() -> UserInputs:
             index=2,
             format_func=lambda x: "/".join(x.split("/")[-3:]),
         )
-        evaluation_case = DEFAULT_EVALUATION_CASE
+        evaluation_case = copy.deepcopy(DEFAULT_EVALUATION_CASE)
         evaluation_case.llm_judge = evaluation_model_id
         # make this an editable json section
         # convert the checkpoints to a df series so that it can be edited

--- a/demo/services/agent.py
+++ b/demo/services/agent.py
@@ -3,7 +3,6 @@ from components.inputs import UserInputs
 from constants import DEFAULT_TOOLS
 from components.agent_status import export_logs
 import streamlit as st
-import time
 from surf_spot_finder.config import Config
 from any_agent import AgentConfig, AnyAgent, TracingConfig, AgentFramework
 from any_agent.tracing.trace import AgentTrace, TotalTokenUseAndCost, AgentSpan
@@ -12,11 +11,10 @@ from any_agent.evaluation import evaluate, TraceEvaluationResult
 
 
 async def display_evaluation_results(result: TraceEvaluationResult):
-    all_results = (
-        result.checkpoint_results
-        + result.hypothesis_answer_results
-        + result.direct_results
-    )
+    if result.ground_truth_result is not None:
+        all_results = [*result.checkpoint_results, result.ground_truth_result]
+    else:
+        all_results = result.checkpoint_results
 
     # Create columns for better layout
     col1, col2 = st.columns(2)
@@ -102,7 +100,7 @@ async def configure_agent(user_inputs: UserInputs) -> tuple[AnyAgent, Config]:
     return agent, config
 
 
-async def display_output(agent_trace: AgentTrace, execution_time: float):
+async def display_output(agent_trace: AgentTrace):
     # Display the agent trace in a more organized way
     with st.expander("### 🧩 Agent Trace"):
         for span in agent_trace.spans:
@@ -142,8 +140,9 @@ async def display_output(agent_trace: AgentTrace, execution_time: float):
     cost: TotalTokenUseAndCost = agent_trace.get_total_cost()
     with st.expander("### 🏄 Results", expanded=True):
         time_col, cost_col, tokens_col = st.columns(3)
+        duration = agent_trace.duration.total_seconds()
         with time_col:
-            st.info(f"⏱️ Execution Time: {execution_time:.2f} seconds")
+            st.info(f"⏱️ Execution Time: {duration:0.2f} seconds")
         with cost_col:
             st.info(f"💰 Estimated Cost: ${cost.total_cost:.6f}")
         with tokens_col:
@@ -152,7 +151,7 @@ async def display_output(agent_trace: AgentTrace, execution_time: float):
         st.info(agent_trace.final_output)
 
 
-async def run_agent(agent, config) -> tuple[AgentTrace, float]:
+async def run_agent(agent, config) -> AgentTrace:
     st.markdown("#### 🔍 Running Surf Spot Finder with query")
 
     query = config.input_prompt_template.format(
@@ -222,11 +221,8 @@ async def run_agent(agent, config) -> tuple[AgentTrace, float]:
             status.update(label=message, expanded=False, state="running")
 
         export_logs(agent, update_span)
-        start_time = time.time()
         agent_trace: AgentTrace = await agent.run_async(query, **kwargs)
         status.update(label="Finished!", expanded=False, state="complete")
-        end_time = time.time()
 
         agent.exit()
-        execution_time = end_time - start_time
-        return agent_trace, execution_time
+        return agent_trace

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ license = {text = "Apache-2.0"}
 requires-python = ">=3.11"
 dynamic = ["version"]
 dependencies = [
-  "any-agent[all]>=0.12.2",
+  "any-agent[all]>=0.14.2",
   "fire",
   "pydantic",
   "pyyaml",


### PR DESCRIPTION
This description was generated by Copilot, edited by me:

This pull request includes several updates to improve code clarity, functionality, and dependency management in the `demo` application. Key changes include refactoring the agent execution flow to remove redundant timing logic, ensuring deep copies for default evaluation cases, and updating a dependency version.

### Refactoring and Code Simplification:
* Removed the `execution_time` parameter from `run_agent` and `display_output` functions, replacing it with the `duration` attribute from `AgentTrace` for execution time reporting. This eliminates redundant timing logic. (`demo/app.py` [[1]](diffhunk://#diff-9cf97de43f27d5f48ea9dd7c5051bd018c246bcd5d35ec74811bbb7fff76246cL43-R45) `demo/services/agent.py` [[2]](diffhunk://#diff-532cbd4d8de432ea48efee34777ec9f1a0612b58e529de29eb803853966ee518L105-R103) [[3]](diffhunk://#diff-532cbd4d8de432ea48efee34777ec9f1a0612b58e529de29eb803853966ee518R143-R145) [[4]](diffhunk://#diff-532cbd4d8de432ea48efee34777ec9f1a0612b58e529de29eb803853966ee518L155-R154) [[5]](diffhunk://#diff-532cbd4d8de432ea48efee34777ec9f1a0612b58e529de29eb803853966ee518L225-R228)

### Functional Improvements:
* Updated the evaluation case initialization in `get_user_inputs` to use `copy.deepcopy` for creating a deep copy of the `DEFAULT_EVALUATION_CASE`, ensuring modifications do not affect the original object. (`demo/components/inputs.py` [demo/components/inputs.pyL101-R102](diffhunk://#diff-20f88132db18ae024ecf96e053ac4f97ef24b91520a1ba83eafa6194a3b643d2L101-R102))

### Dependency Management:
* Upgraded the `any-agent` dependency version from `0.12.2` to `0.14.2` in `pyproject.toml` to ensure compatibility with the latest features and fixes. (`pyproject.toml` [pyproject.tomlL12-R12](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L12-R12))
